### PR TITLE
Severity recasting

### DIFF
--- a/spec/dradis/plugins/nessus/field_processor_spec.rb
+++ b/spec/dradis/plugins/nessus/field_processor_spec.rb
@@ -16,4 +16,12 @@ describe Dradis::Plugins::Nessus::FieldProcessor do
       end
     end
   end
+
+  it "Recasted severity values appear in the Evidence" do
+    doc = Nokogiri::XML(File.read('spec/fixtures/files/report_item-with-list.xml'))
+    processor = described_class.new(data: doc.root)
+    value = processor.value(field: 'evidence.severity')
+    expect(value).to_not be_empty
+    expect(value).to include("2")
+  end
 end

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -13,3 +13,4 @@ evidence.plugin_output
 evidence.port
 evidence.protocol
 evidence.svc_name
+evidence.severity

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,6 +1,8 @@
 #[Port]#
 %evidence.port%
 
+#[Severity]#
+%evidence.severity%
 
 #[Output]#
 bc.. %evidence.plugin_output%


### PR DESCRIPTION
Add the `evidence.severity` fields to the list of available fields in the Evidence template so that recasted Issues can be properly exported into reports. 