### PR TITLE
Make Issue Title available at the Evidence level

### DIFF
--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 10
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -14,3 +14,4 @@ evidence.port
 evidence.protocol
 evidence.svc_name
 evidence.severity
+report_item.plugin_name


### PR DESCRIPTION
This PR resolves https://github.com/dradis/dradis-ce/issues/312. 

Currently, if you merge multiple Issues together, there's no way to identify which Issue each instance of Evidence originally came from. In the case of similar patches, some teams want to be able to report one merged Issue, then report which specific instance of Evidence refers to which specific patch. This PR allows teams to include the Issue Title at the Evidence level so that reports like this are possible: 

```
10.10.10.10   (IP)
MS14-025: Vulnerability in Group Policy Preferences Could Allow Elevation of Privilege
```

Even if the Issue title is more general like "Microsoft Patches". 