### PR TITLE
Fix for weird Nessus bullet list spaces in Desc

### DIFF
--- a/lib/dradis/plugins/nessus/field_processor.rb
+++ b/lib/dradis/plugins/nessus/field_processor.rb
@@ -28,7 +28,7 @@ module Dradis
           else
             output = @nessus_object.try(name) || 'n/a'
 
-            if field == 'report_item.description' && output =~ /^  -/
+            if field == 'report_item.description' && output =~ /^\s+-/
               format_bullet_point_lists(output)
             else
               output
@@ -39,12 +39,14 @@ module Dradis
         private
         def format_bullet_point_lists(input)
           input.split("\n").map do |paragraph|
-            if paragraph =~ /^  - (.*)$/m
-              '* ' + $1.gsub(/    /, '').gsub(/\n/, ' ')
-            else
-              paragraph
-            end
-          end.join("\n\n")
+						if paragraph =~ /(.*)\s+:\s*$/m
+							$1 + ':'
+						elsif paragraph =~ /^\s+-\s+(.*)$/m
+					  	'* ' + $1.gsub(/\s{3,}/, ' ').gsub(/\n/, ' ')
+					 	else
+					  	paragraph
+					 	end
+					end.join("\n")
         end
       end
 

--- a/lib/dradis/plugins/nessus/field_processor.rb
+++ b/lib/dradis/plugins/nessus/field_processor.rb
@@ -39,14 +39,14 @@ module Dradis
         private
         def format_bullet_point_lists(input)
           input.split("\n").map do |paragraph|
-						if paragraph =~ /(.*)\s+:\s*$/m
-							$1 + ':'
-						elsif paragraph =~ /^\s+-\s+(.*)$/m
-					  	'* ' + $1.gsub(/\s{3,}/, ' ').gsub(/\n/, ' ')
-					 	else
-					  	paragraph
-					 	end
-					end.join("\n")
+            if paragraph =~ /(.*)\s+:\s*$/m
+              $1 + ':'
+            elsif paragraph =~ /^\s+-\s+(.*)$/m
+              '* ' + $1.gsub(/\s{3,}/, ' ').gsub(/\n/, ' ')
+            else
+              paragraph
+            end
+          end.join("\n")
         end
       end
 


### PR DESCRIPTION
### Summary

Nessus plugins use odd internal text column widths, which ends up putting 5 spaces in the bullet lists due to word wrapping issues.  Changed the "format_bullet_point_lists" function to address that and the space before the colon.

### Other Information
None


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
