### PR TITLE
Fix nessus bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.15 (XXX, 2019) ##
+
+*   Fixed bullet points formatting to handle internal text column widths
+
 ## Dradis Framework 3.14 (August, 2019) ##
 
 *   No changes.

--- a/lib/dradis/plugins/nessus/field_processor.rb
+++ b/lib/dradis/plugins/nessus/field_processor.rb
@@ -28,7 +28,7 @@ module Dradis
           else
             output = @nessus_object.try(name) || 'n/a'
 
-            if field == 'report_item.description' && output =~ /^  -/
+            if field == 'report_item.description' && output =~ /^\s+-/
               format_bullet_point_lists(output)
             else
               output
@@ -39,12 +39,14 @@ module Dradis
         private
         def format_bullet_point_lists(input)
           input.split("\n").map do |paragraph|
-            if paragraph =~ /^  - (.*)$/m
-              '* ' + $1.gsub(/    /, '').gsub(/\n/, ' ')
+            if paragraph =~ /(.*)\s+:\s*$/m
+              $1 + ':'
+            elsif paragraph =~ /^\s+-\s+(.*)$/m
+              '* ' + $1.gsub(/\s{3,}/, ' ').gsub(/\n/, ' ')
             else
               paragraph
             end
-          end.join("\n\n")
+          end.join("\n")
         end
       end
 

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 14
+        MINOR = 15
         TINY = 0
         PRE = nil
 

--- a/spec/dradis/plugins/nessus/field_processor_spec.rb
+++ b/spec/dradis/plugins/nessus/field_processor_spec.rb
@@ -3,25 +3,39 @@ require 'ostruct'
 
 describe Dradis::Plugins::Nessus::FieldProcessor do
 
-  describe "%report_item.description% field formatting" do
-    context "bullet points" do
-      it "converts Nessus broken lists into Textile bullet-point lists" do
-        doc = Nokogiri::XML(File.read('spec/fixtures/files/report_item-with-list.xml'))
+  describe '%report_item.description% field formatting' do
+    context 'bullet points' do
+      before do
+        doc = Nokogiri::XML(
+          File.read('spec/fixtures/files/report_item-with-list.xml')
+        )
         processor = described_class.new(data: doc.root)
 
-        value = processor.value(field: 'report_item.description')
-        expect(value).to_not be_empty
+        @value = processor.value(field: 'report_item.description')
+      end
 
-        expect(value).to include("* A denial of service vulnerability exists relating to the 'mod_dav' module as it relates to MERGE requests. (CVE-2013-1896)")
+      it 'converts Nessus broken lists into Textile bullet-point lists' do
+        expect(@value).to_not be_empty
+
+        expect(@value).to include(
+          '* A denial of service vulnerability exists relating to '\
+          'the \'mod_dav\' module as it relates to MERGE requests.'
+        )
+      end
+
+      it 'does not add unnecessary newlines to list items' do
+        expect(@value).to include("vulnerabilities:\n\n* A flaw exists")
       end
     end
   end
 
-  it "Recasted severity values appear in the Evidence" do
-    doc = Nokogiri::XML(File.read('spec/fixtures/files/report_item-with-list.xml'))
+  it 'Recasted severity values appear in the Evidence' do
+    doc = Nokogiri::XML(
+      File.read('spec/fixtures/files/report_item-with-list.xml')
+    )
     processor = described_class.new(data: doc.root)
     value = processor.value(field: 'evidence.severity')
     expect(value).to_not be_empty
-    expect(value).to include("2")
+    expect(value).to include('2')
   end
 end


### PR DESCRIPTION
### Spec
The following content straight from the Nessus file:
```
- First, the top of the certificate chain sent by the     server might not be descended from a known public     certificate authority. This can occur either when the     top of the chain is an unrecognized, self-signed     certificate, or when intermediate certificates are     missing that would connect the top of the certificate     chain to a known public certificate authority.

``` 

Is actually supposed to be this: 

```
- First, the top of the certificate chain sent by the server might not be descended from a known public certificate authority. This can occur either when the top of the chain is an unrecognized, self-signed certificate, or when intermediate certificates are missing that would connect the top of the certificate chain to a known public certificate authority.
```

Stings of 5/8 spaces in a row need to be stripped from the Description field. 


**Proposed Solution**
Fix handling of bullet points formatting in the FieldProcessor

### How to test

1. Upload a nessus file with a report item with bullet points.
2. Confirm that the report item was imported with no extra spaces.

