### PR TITLE
Add new CVSSv3 Temporal fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.22 (MMMM, 2021) ##
+
+*   Add report_item.cvss3_temporal_score & report_item.cvss3_temporal_vector as available fields
+
 ## Dradis Framework 3.21 (February, 2021) ##
 
 *   No changes.

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -19,15 +19,15 @@ module Nessus
     def supported_tags
       [
         # attributes
-        :port, :svc_name, :protocol, :severity, :plugin_id, :plugin_name, :plugin_family,
+        :plugin_family, :plugin_id, :plugin_name, :port, :protocol, :svc_name, :severity, 
         # simple tags
-        :solution, :risk_factor, :description, :plugin_publication_date,
-        :metasploit_name, :cvss_vector, :cvss3_vector, :cvss_temporal_vector, :synopsis,
-        :exploit_available, :patch_publication_date, :plugin_modification_date,
-        :cvss_temporal_score, :cvss_base_score, :cvss3_base_score, :plugin_output,
-        :plugin_version, :exploitability_ease, :vuln_publication_date,
-        :exploit_framework_canvas, :exploit_framework_metasploit,
-        :exploit_framework_core,
+        :cvss3_base_score, :cvss3_temporal_score, :cvss3_temporal_vector, :cvss3_vector,
+        :cvss_base_score, :cvss_temporal_score, :cvss_temporal_vector, :cvss_vector,
+        :description, :exploit_available, :exploit_framework_canvas, :exploit_framework_core,
+        :exploitability_ease, :exploit_framework_metasploit,
+        :metasploit_name, :patch_publication_date, :plugin_modification_date, :plugin_output,
+        :plugin_publication_date, :plugin_version, :risk_factor,
+        :solution, :synopsis, :vuln_publication_date,
         # multiple tags
         :bid_entries, :cve_entries, :see_also_entries, :xref_entries,
         # compliance tags

--- a/templates/report_item.fields
+++ b/templates/report_item.fields
@@ -18,7 +18,9 @@ report_item.metasploit_name
 report_item.cvss_vector
 report_item.cvss3_vector
 report_item.cvss_temporal_vector
+report_item.cvss3_temporal_vector
 report_item.cvss_temporal_score
+report_item.cvss3_temporal_score
 report_item.cvss_base_score
 report_item.cvss3_base_score
 report_item.synopsis

--- a/templates/report_item.sample
+++ b/templates/report_item.sample
@@ -24,6 +24,8 @@ If safe checks are enabled, this may be a false positive since it is based on th
   <plugin_publication_date>2002/06/17</plugin_publication_date>
   <metasploit_name>Apache Win32 Chunked Encoding</metasploit_name>
   <cvss3_base_score>3.7</cvss3_base_score>
+  <cvss3_temporal_score>6.8</cvss3_temporal_score>
+  <cvss3_temporal_vector>CVSS:3.0/E:U/RL:O/RC:C</cvss3_temporal_vector>
   <cvss3_vector>CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N</cvss3_vector>
   <cvss_vector>CVSS2#AV:N/AC:L/Au:N/C:P/I:P/A:P</cvss_vector>
   <synopsis>The remote web server is vulnerable to a remote code execution attack.</synopsis>

--- a/templates/report_item.template
+++ b/templates/report_item.template
@@ -7,6 +7,10 @@
 #[CVSSv3Vector]#
 %report_item.cvss3_vector%
 
+#[Temporal]#
+Score: %report_item.cvss3_temporal_score%
+Vector: %report_item.cvss3_temporal_vector%
+
 #[Type]#
 Internal
 

--- a/templates/report_item.template
+++ b/templates/report_item.template
@@ -7,10 +7,6 @@
 #[CVSSv3Vector]#
 %report_item.cvss3_vector%
 
-#[Temporal]#
-Score: %report_item.cvss3_temporal_score%
-Vector: %report_item.cvss3_temporal_vector%
-
 #[Type]#
 Internal
 


### PR DESCRIPTION
### Summary

Adds 2 new fields to Nessus report item template: 

- :cvss3_temporal_score
- :cvss3_temporal_vector,

Also alphabetizes the list of fields in report_item.rb because it was driving me wild. 

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
