### PR TITLE
Add new VPR-related available fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Dradis Framework X.XX (XXXX, 2021) ##
+
+*   Add age_of_vuln, exploit_code_maturity, threat_intensity_last_28
+    threat_recency, & threat_sources_last_28 as available Issue fields.
+
 ## Dradis Framework 3.22 (April, 2021) ##
 
 *   Add report_item.cvss3_temporal_score & report_item.cvss3_temporal_vector as available fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Dradis Framework X.XX (XXXX, 2021) ##
+## Dradis Framework 4.00 (XXXX, 2021) ##
 
 *   Add age_of_vuln, exploit_code_maturity, threat_intensity_last_28
     threat_recency, & threat_sources_last_28 as available Issue fields.

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -7,8 +7,8 @@ module Dradis
       end
 
       module VERSION
-        MAJOR = 3
-        MINOR = 22
+        MAJOR = 4
+        MINOR = 0
         TINY = 0
         PRE = nil
 

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -21,13 +21,14 @@ module Nessus
         # attributes
         :plugin_family, :plugin_id, :plugin_name, :port, :protocol, :svc_name, :severity, 
         # simple tags
-        :cvss3_base_score, :cvss3_temporal_score, :cvss3_temporal_vector, :cvss3_vector,
-        :cvss_base_score, :cvss_temporal_score, :cvss_temporal_vector, :cvss_vector,
-        :description, :exploit_available, :exploit_framework_canvas, :exploit_framework_core,
-        :exploitability_ease, :exploit_framework_metasploit,
+        :age_of_vuln, :cvss3_base_score, :cvss3_temporal_score, :cvss3_temporal_vector, 
+        :cvss3_vector, :cvss_base_score, :cvss_temporal_score, :cvss_temporal_vector, :cvss_vector,
+        :description, :exploit_available, :exploit_code_maturity, :exploit_framework_canvas, 
+        :exploit_framework_core, :exploitability_ease, :exploit_framework_metasploit,
         :metasploit_name, :patch_publication_date, :plugin_modification_date, :plugin_output,
-        :plugin_publication_date, :plugin_version, :risk_factor,
-        :solution, :synopsis, :vpr_score, :vuln_publication_date,
+        :plugin_publication_date, :plugin_version, :risk_factor, :solution, :synopsis, 
+        :threat_intensity_last_28, :threat_recency, :threat_sources_last_28, :vpr_score, 
+        :vuln_publication_date,
         # multiple tags
         :bid_entries, :cve_entries, :see_also_entries, :xref_entries,
         # compliance tags

--- a/templates/report_item.fields
+++ b/templates/report_item.fields
@@ -1,3 +1,4 @@
+report_item.age_of_vuln
 report_item.bid_entries
 report_item.cve_entries
 report_item.cvss3_base_score
@@ -11,6 +12,7 @@ report_item.cvss_vector
 report_item.description
 report_item.exploitability_ease
 report_item.exploit_available
+report_item.exploit_code_maturity
 report_item.exploit_framework_canvas
 report_item.exploit_framework_core
 report_item.exploit_framework_metasploit
@@ -31,6 +33,9 @@ report_item.severity
 report_item.solution
 report_item.svc_name
 report_item.synopsis
+report_item.threat_intensity_last_28
+report_item.threat_recency
+report_item.threat_sources_last_28
 report_item.vpr_score
 report_item.vuln_publication_date
 report_item.xref_entries

--- a/templates/report_item.sample
+++ b/templates/report_item.sample
@@ -7,6 +7,7 @@
   pluginName="Apache Chunked Encoding Remote Overflow"
   pluginFamily="Web Servers">
 
+  <age_of_vuln>730 days +</age_of_vuln>
   <exploitability_ease>Exploits are available</exploitability_ease>
   <vuln_publication_date>2002/06/19</vuln_publication_date>
   <exploit_framework_canvas>true</exploit_framework_canvas>
@@ -29,10 +30,14 @@ If safe checks are enabled, this may be a false positive since it is based on th
   <cvss3_vector>CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N</cvss3_vector>
   <cvss_vector>CVSS2#AV:N/AC:L/Au:N/C:P/I:P/A:P</cvss_vector>
   <synopsis>The remote web server is vulnerable to a remote code execution attack.</synopsis>
+  <threat_intensity_last_28>Very Low</threat_intensity_last_28>
+  <threat_recency>&gt; 365 days</threat_recency>
+  <threat_sources_last_28>No recorded events</threat_sources_last_28>
   <plugin_type>remote</plugin_type>
   <see_also>http://httpd.apache.org/info/security_bulletin_20020617.txt</see_also>
   <see_also>http://httpd.apache.org/info/security_bulletin_20020620.txt</see_also>
   <exploit_available>true</exploit_available>
+  <exploit_code_maturity>Unproven</exploit_code_maturity>
   <plugin_modification_date>2011/03/08</plugin_modification_date>
   <cvss_base_score>7.5</cvss_base_score>
   <vpr_score>6.7</vpr_score>


### PR DESCRIPTION
### Summary
Adds the new available fields: 

- report_item.age_of_vuln
- report_item.exploit_code_maturity
- report_item.threat_intensity_last_28
- report_item.threat_recency
- report_item.threat_sources_last_28

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
