### PR TITLE
Version bump v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Dradis Framework 4.00 (XXXX, 2021) ##
+## Dradis Framework 4.0.0 (July, 2021) ##
 
 *   Add age_of_vuln, exploit_code_maturity, threat_intensity_last_28
     threat_recency, & threat_sources_last_28 as available Issue fields.

--- a/dradis-nessus.gemspec
+++ b/dradis-nessus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # versions of Rails (a sure recipe for disaster, I'm sure), which is needed
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
-  spec.add_dependency 'dradis-plugins', '~> 3.6'
+  spec.add_dependency 'dradis-plugins', '~> 4.0.0'
   spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/dradis-nessus.gemspec
+++ b/dradis-nessus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # versions of Rails (a sure recipe for disaster, I'm sure), which is needed
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
-  spec.add_dependency 'dradis-plugins', '~> 4.0.0'
+  spec.add_dependency 'dradis-plugins', '>= 3.0.0'
   spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/dradis-nessus.gemspec
+++ b/dradis-nessus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # versions of Rails (a sure recipe for disaster, I'm sure), which is needed
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
-  spec.add_dependency 'dradis-plugins', '>= 3.0.0'
+  spec.add_dependency 'dradis-plugins', '~> 4.0.0'
   spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
### Summary

- Add age_of_vuln, exploit_code_maturity, threat_intensity_last_28
  threat_recency, and threat_sources_last_28 as available Issue fields


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
