### PR TITLE
Clean up code tags in description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v#.#.# (month YYYY)
+  - Clean up code tags in description fields
+
 v4.6.0 (November 2022)
   - No changes
 

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -87,7 +87,8 @@ module Nessus
       #   exploit_framework_metasploit, exploit_framework_core
       tag = @xml.xpath("./#{method_name}").first
       if tag
-        return tag.text
+        text = tag.text
+        return tags_with_html_content.include?(method) ? cleanup_html(text) : text
       end
 
       # then the custom XML tags (cm: namespace)
@@ -117,5 +118,18 @@ module Nessus
         return nil
       end
     end
+
+    private
+
+    def cleanup_html(source)
+      result = source.dup
+      result.gsub!(/<code>(.*?)<\/code>/) { "\n\nbc. #{$1}\n\np.  \n" }
+      result
+    end
+
+    def tags_with_html_content
+      [:description]
+    end
+
   end
 end


### PR DESCRIPTION
### Summary
Recent Nessus scans contain `<code></code>` tags in the description output which will crash a Word report. This PR converts the `<code>` tags to Dradis code blocks (`bc. `) using the same logic as our other import plugins. 


### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.