### PR TITLE
Add support for inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.X.X (XXXX 2023)
+  - Parse code tags as inline code
+
 v4.7.0 (February 2023)
   - Clean up code tags in description fields
 

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 7
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -123,7 +123,7 @@ module Nessus
 
     def cleanup_html(source)
       result = source.dup
-      result.gsub!(/<code>(.*?)<\/code>/) { "\n\nbc. #{$1}\n\np.  \n" }
+      result.gsub!(/<code>(.*?)<\/code>/) { "@#{$1}@" }
       result
     end
 


### PR DESCRIPTION
### Summary

This PR parses `<code>` tags as inline code to prevent unnecessary line breaks in reports. 


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.