### PR TITLE
Parse double asterisks correctly to avoid export errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v4.7.0 (February 2023)
   - Clean up code tags in description fields
+  - Parse `**` correctly in the description field
 
 v4.6.0 (November 2022)
   - No changes

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 7
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -124,6 +124,7 @@ module Nessus
     def cleanup_html(source)
       result = source.dup
       result.gsub!(/<code>(.*?)<\/code>/) { "\n\nbc. #{$1}\n\np.  \n" }
+      result.gsub!(/^\s*\*\*/, "\np. **")
       result
     end
 


### PR DESCRIPTION
### Summary

Including `**` in the report will crash the export. Wrapping them in a paragraph marker like `p. **` will prevent export errors. 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
