### PR TITLE
Add CVE as an available Evidence field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v4.X.X (XXXX 2023)
   - Parse code tags as inline code
   - Add plugin_type as an available Issue field
+  - Add cve_entries as an available Evidence field
 
 v4.8.0 (April 2023)
   - No changes

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 8
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -15,3 +15,4 @@ evidence.protocol
 evidence.svc_name
 evidence.severity
 report_item.plugin_name
+report_item.cve_entries


### PR DESCRIPTION
### Summary

This PR makes `report_item.cve_entries` available at the Evidence level rather than just the Issue level. This allows a record of CVEs even in cases where multiple Issues are merged or de-duplicated. 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
