### PR TITLE
Add cwe_entries as available Issue field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-v4.12.0 (Mmmm 2024)
+v4.13.0 (Mmmm 2024)
+ - Add `cwe_entries` as an available Issue field
+
+v4.12.0 (May 2024)
  - Migrate integration to use Mappings Manager
  - Update Dradis links in README
 

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 12
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/nessus/gem_version.rb
+++ b/lib/dradis/plugins/nessus/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 12
-        TINY = 1
+        MINOR = 13
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/nessus/mapping.rb
+++ b/lib/dradis/plugins/nessus/mapping.rb
@@ -55,6 +55,7 @@ module Dradis::Plugins::Nessus
         'report_item.age_of_vuln',
         'report_item.bid_entries',
         'report_item.cve_entries',
+        'report_item.cwe_entries',
         'report_item.cvss3_base_score',
         'report_item.cvss3_impact_score',
         'report_item.cvss3_temporal_score',

--- a/lib/nessus/report_item.rb
+++ b/lib/nessus/report_item.rb
@@ -31,7 +31,7 @@ module Nessus
         :risk_factor, :solution, :synopsis, :threat_intensity_last_28, :threat_recency, 
         :threat_sources_last_28, :vpr_score, :vuln_publication_date,
         # multiple tags
-        :bid_entries, :cve_entries, :see_also_entries, :xref_entries,
+        :bid_entries, :cve_entries, :cwe_entries, :see_also_entries, :xref_entries,
         # compliance tags
         :cm_actual_value, :cm_audit_file, :cm_check_id, :cm_check_name, :cm_info,
         :cm_output, :cm_policy_value, :cm_reference, :cm_result, :cm_see_also,
@@ -107,6 +107,7 @@ module Nessus
       translations_table = {
         :bid_entries => 'bid',
         :cve_entries => 'cve',
+        :cwe_entries => 'cwe',
         :see_also_entries => 'see_also',
         :xref_entries  => 'xref'
       }

--- a/spec/dradis/plugins/nessus/importer_spec.rb
+++ b/spec/dradis/plugins/nessus/importer_spec.rb
@@ -2,13 +2,10 @@ require 'spec_helper'
 require 'ostruct'
 
 describe Dradis::Plugins::Nessus::Importer do
-
   before(:each) do
-    # Stub template service
-    templates_dir = File.expand_path('../../../../../templates', __FILE__)
-    expect_any_instance_of(Dradis::Plugins::TemplateService)
-    .to receive(:default_templates_dir).and_return(templates_dir)
-
+    mapping_service = double('Dradis::Plugins::MappingService')
+    allow(mapping_service).to receive(:apply_mapping).and_return('')
+    allow(Dradis::Plugins::MappingService).to receive(:new).and_return(mapping_service)
 
     # Init services
     plugin = Dradis::Plugins::Nessus

--- a/templates/report_item.sample
+++ b/templates/report_item.sample
@@ -46,6 +46,7 @@ If safe checks are enabled, this may be a false positive since it is based on th
   <product_coverage>Low</product_coverage>
   <canvas_package>CANVAS</canvas_package>
   <cve>CVE-2002-0392</cve>
+  <cwe>123</cwe>
   <bid>5033</bid>
   <xref>IAVA:2002-a-0003</xref>
   <xref>OSVDB:838</xref>


### PR DESCRIPTION
### Summary

This PR adds `{{ nessus[report_item.cwe_entries] }}` as a new available Issue field


### Testing Steps
1. Configure the Mappings Manager like: 
```
{{ nessus[report_item.cwe_entries] }}
{{ nessus[report_item.cve_entries] }}
```
2. Upload a sample Nessus file and confirm that the CWE (and CVE!) entries appear as expected in the Issues

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
